### PR TITLE
feat(skill-digest): add blake2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +592,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1992,6 +2002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +2606,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bigdecimal",
+ "blake2",
  "chardetng",
  "chrono",
  "chrono-tz",

--- a/skillset/Cargo.toml
+++ b/skillset/Cargo.toml
@@ -52,6 +52,7 @@ num-bigint = { version = "0.4", optional = true }
 fuzzydate = { version = "0.1.5", optional = true }
 chrono-tz = { version = "0.6.1", optional = true }
 open-location-code = { version = "0.1.0", optional = true }
+blake2 = { version = "0.10.4", optional = true }
 
 [features]
 default = [
@@ -92,7 +93,8 @@ yozuk-skill-digest = [
     "sha1",
     "sha2",
     "sha3",
-    "crc_all"
+    "crc_all", 
+    "blake2"
 ]
 yozuk-skill-color = ["css-color", "palette"]
 yozuk-skill-time = ["chrono", "fuzzydate", "chrono-tz"]

--- a/skillset/src/digest/algorithm.rs
+++ b/skillset/src/digest/algorithm.rs
@@ -99,6 +99,16 @@ pub const ENTRIES: &[AlgorithmEntry] = &[
             )))
         },
     },
+    AlgorithmEntry {
+        name: "BLAKE2-S-256",
+        keywords: &["blake2s256", "blake2"],
+        init: || Box::new(DigestEntry::<blake2::Blake2s256>::new()),
+    },
+    AlgorithmEntry {
+        name: "BLAKE2-B-512",
+        keywords: &["blake2b512", "blake2"],
+        init: || Box::new(DigestEntry::<blake2::Blake2b512>::new()),
+    },
 ];
 
 pub struct AlgorithmEntry {


### PR DESCRIPTION
Close #5 

Example

```
$ zuk blake2 < Cargo.toml
BLAKE2-B-512: 5c0c05f4bb4473cfb685e6d4877bfa223dcfcf7687db6b49711f5e5969d42210954eebdcfb74a605ee17ac7eee0b990fe4f7cdb984265dfc4227650ae9486b7d
BLAKE2-S-256: e803a36af44435cac7c2e85ff542a420d1e8b77829d6b5c772bb0fb883a6c42

$ zuk blake2b512 < Cargo.toml
5c0c05f4bb4473cfb685e6d4877bfa223dcfcf7687db6b49711f5e5969d42210954eebdcfb74a605ee17ac7eee0b990fe4f7cdb984265dfc4227650ae9486b7d

$ zuk blake2s256 < Cargo.toml
e803a36af44435cac7c2e85ff542a420d1e8b77829d6b5c772bb0fb883a6c42a
```